### PR TITLE
Update Default Random Move Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,9 @@ Example, if you just want to play an animation, return true, if the character wi
 
 ```luau
     pos = Vector3.new(
-        RootPart.Position.X + math.random(0, 6), 
+        RootPart.Position.X + math.random(-6, 6), 
         RootPart.Position.Y + math.random(0, 2), 
-        RootPart.Position.Z + math.random(0, 6)
+        RootPart.Position.Z + math.random(-6, 6)
     )
 ```
 

--- a/src/modules/Pathfinder/PathfinderClass/PathfinderMethods/init.luau
+++ b/src/modules/Pathfinder/PathfinderClass/PathfinderMethods/init.luau
@@ -61,9 +61,9 @@ function PathfinderMethods:_RandomMove()
 
 			if RootPart then
 				pos = Vector3.new(
-					RootPart.Position.X + math.random(0, 6), 
+					RootPart.Position.X + math.random(-6, 6), 
 					RootPart.Position.Y + math.random(0, 2), 
-					RootPart.Position.Z + math.random(0, 6)
+					RootPart.Position.Z + math.random(-6, 6)
 				)
 			end
 		end


### PR DESCRIPTION
Include negative numbers in the random move function to prevent the AI from randomly wandering northwest, instead give them all directions.